### PR TITLE
Test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
 permissions:
   contents: read
+  #
 jobs:
   full:
     name: Node.js Latest Full


### PR DESCRIPTION
- [ ] Install Vitest
  - [ ] Migrate sub-packages
  - [ ] dual-publish
 esbuild
 figure out why sizes differ way too much (231 405 bytes)
 esbuild-why
 file
 preset-app
 preset-big-lib
 preset-small-lib
 size-limit
 third party plugin used for testing uses imports incorrectly (without an extension)
 time
- [ ] we could've used estimo v3 with ESM, but it's not available (https://github.com/mbalabash/estimo/issues/43)
- [ ] test/get-running-time.test.js > calculates running time doesn't run on my machine, both Jest and Vitest
 webpack
 webpack-css
 figure out why it doesn't seem to bundle CSS at all (1450 70 bytes)
 webpack-why
 update ESLint config
- [ ] test JS config with ESM